### PR TITLE
Add classnames package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-eslint": "^7.0.0",
     "babel-polyfill": "^6.16.0",
+    "classnames": "^2.2.5",
     "document-register-element": "^1.2.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",


### PR DESCRIPTION
When I start dev server `npm start`, an error occurred `classnames` packages not found.

P.S. Fantastic example! Thanks for sharing 😃 
