### PR TITLE
added classnames dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-eslint": "^7.0.0",
     "babel-polyfill": "^6.16.0",
+    "classnames": "^2.2.5",
     "document-register-element": "^1.2.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",


### PR DESCRIPTION
It seemed to be missing a dependency for those that don't have 'classnames' installed globally.
I'm new to react and node but thought you might want to know assuming it's not intentional?
