### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run start"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Rubix - A Rubik's Cube with Redux
+[![run on repl.it](http://repl.it/badge/github/Zacqary/rubix)](https://repl.it/github/Zacqary/rubix)
+
 ![Screenshot of Rubix](screenshot.png)
 
 [Live Demo](https://zacqary.github.io/rubix)


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-rubix):

![image](https://i.imgur.com/E9dt0wS.png)